### PR TITLE
Put record construction in a less odd place

### DIFF
--- a/Plugins/ArgParser/WoofWare.Whippet.Plugin.ArgParser/ArgParserGenerator.fs
+++ b/Plugins/ArgParser/WoofWare.Whippet.Plugin.ArgParser/ArgParserGenerator.fs
@@ -661,7 +661,7 @@ module internal ArgParserGenerator =
                 args
                 |> Map.toList
                 |> List.map (fun (ident, expr) -> SynLongIdent.create [ Ident.create ident ], expr)
-                |> AstHelper.instantiateRecord
+                |> SynExpr.createRecord None
             )
 
         tree, counter

--- a/Plugins/InterfaceMock/WoofWare.Whippet.Plugin.InterfaceMock/InterfaceMockGenerator.fs
+++ b/Plugins/InterfaceMock/WoofWare.Whippet.Plugin.InterfaceMock/InterfaceMockGenerator.fs
@@ -90,7 +90,7 @@ module internal InterfaceMockGenerator =
                      []
                  else
                      [ SynPat.unit ])
-                (AstHelper.instantiateRecord constructorFields)
+                (SynExpr.createRecord None constructorFields)
             |> SynBinding.withXmlDoc (PreXmlDoc.create "An implementation where every method throws.")
             |> SynBinding.withReturnAnnotation constructorReturnType
             |> SynMemberDefn.staticMember

--- a/Plugins/Json/WoofWare.Whippet.Plugin.Json/JsonParseGenerator.fs
+++ b/Plugins/Json/WoofWare.Whippet.Plugin.Json/JsonParseGenerator.fs
@@ -486,7 +486,7 @@ module JsonParseGenerator =
         let finalConstruction =
             fields
             |> List.mapi (fun i fieldData -> SynLongIdent.createI fieldData.Ident, SynExpr.createIdent $"arg_%i{i}")
-            |> AstHelper.instantiateRecord
+            |> SynExpr.createRecord None
 
         (finalConstruction, assignments)
         ||> List.fold (fun final assignment -> SynExpr.createLet [ assignment ] final)

--- a/WoofWare.Whippet.Fantomas.Test/TestSurface.fs
+++ b/WoofWare.Whippet.Fantomas.Test/TestSurface.fs
@@ -12,12 +12,10 @@ module TestSurface =
     [<Test>]
     let ``Ensure API surface has not been modified`` () = ApiSurface.assertIdentical coreAssembly
 
-    (*
     [<Test>]
     // https://github.com/nunit/nunit3-vs-adapter/issues/876
     let CheckVersionAgainstRemote () =
-        MonotonicVersion.validate assembly "WoofWare.Whippet.Fantomas"
-    *)
+        MonotonicVersion.validate coreAssembly "WoofWare.Whippet.Fantomas"
 
     [<Test ; Explicit>]
     let ``Update API surface`` () =

--- a/WoofWare.Whippet.Fantomas/AstHelper.fs
+++ b/WoofWare.Whippet.Fantomas/AstHelper.fs
@@ -234,15 +234,6 @@ type UnionType =
 /// Miscellaneous methods for manipulating AST types.
 [<RequireQualifiedAccess>]
 module AstHelper =
-
-    /// Construct a record from the given fields.
-    let instantiateRecord (fields : (SynLongIdent * SynExpr) list) : SynExpr =
-        let fields =
-            fields
-            |> List.map (fun (rfn, synExpr) -> SynExprRecordField ((rfn, true), Some range0, Some synExpr, None))
-
-        SynExpr.Record (None, None, fields, range0)
-
     let rec private extractOpensFromDecl (moduleDecls : SynModuleDecl list) : SynOpenDeclTarget list =
         moduleDecls
         |> List.choose (fun moduleDecl ->

--- a/WoofWare.Whippet.Fantomas/SurfaceBaseline.txt
+++ b/WoofWare.Whippet.Fantomas/SurfaceBaseline.txt
@@ -5,7 +5,6 @@ WoofWare.Whippet.Fantomas.Ast.parse [static method]: string -> Fantomas.FCS.Synt
 WoofWare.Whippet.Fantomas.Ast.render [static method]: Fantomas.FCS.Syntax.SynModuleOrNamespace list -> string option
 WoofWare.Whippet.Fantomas.AstHelper inherit obj
 WoofWare.Whippet.Fantomas.AstHelper.extractOpens [static method]: Fantomas.FCS.Syntax.ParsedInput -> Fantomas.FCS.Syntax.SynOpenDeclTarget list
-WoofWare.Whippet.Fantomas.AstHelper.instantiateRecord [static method]: (Fantomas.FCS.Syntax.SynLongIdent * Fantomas.FCS.Syntax.SynExpr) list -> Fantomas.FCS.Syntax.SynExpr
 WoofWare.Whippet.Fantomas.AstHelper.parseInterface [static method]: Fantomas.FCS.Syntax.SynTypeDefn -> WoofWare.Whippet.Fantomas.InterfaceType
 WoofWare.Whippet.Fantomas.CompExprBinding inherit obj - union type with 4 cases
 WoofWare.Whippet.Fantomas.CompExprBinding+Do inherit WoofWare.Whippet.Fantomas.CompExprBinding
@@ -226,6 +225,7 @@ WoofWare.Whippet.Fantomas.SynExpr.createLongIdent'' [static method]: Fantomas.FC
 WoofWare.Whippet.Fantomas.SynExpr.createMatch [static method]: Fantomas.FCS.Syntax.SynExpr -> Fantomas.FCS.Syntax.SynMatchClause list -> Fantomas.FCS.Syntax.SynExpr
 WoofWare.Whippet.Fantomas.SynExpr.createNew [static method]: Fantomas.FCS.Syntax.SynType -> Fantomas.FCS.Syntax.SynExpr -> Fantomas.FCS.Syntax.SynExpr
 WoofWare.Whippet.Fantomas.SynExpr.createNull [static method]: unit -> Fantomas.FCS.Syntax.SynExpr
+WoofWare.Whippet.Fantomas.SynExpr.createRecord [static method]: Fantomas.FCS.Syntax.SynExpr option -> (Fantomas.FCS.Syntax.SynLongIdent * Fantomas.FCS.Syntax.SynExpr) list -> Fantomas.FCS.Syntax.SynExpr
 WoofWare.Whippet.Fantomas.SynExpr.createThunk [static method]: Fantomas.FCS.Syntax.SynExpr -> Fantomas.FCS.Syntax.SynExpr
 WoofWare.Whippet.Fantomas.SynExpr.createWhile [static method]: Fantomas.FCS.Syntax.SynExpr -> Fantomas.FCS.Syntax.SynExpr -> Fantomas.FCS.Syntax.SynExpr
 WoofWare.Whippet.Fantomas.SynExpr.dotGet [static method]: string -> Fantomas.FCS.Syntax.SynExpr -> Fantomas.FCS.Syntax.SynExpr

--- a/WoofWare.Whippet.Fantomas/SynExpr.fs
+++ b/WoofWare.Whippet.Fantomas/SynExpr.fs
@@ -413,3 +413,15 @@ module SynExpr =
     /// `{lhs}.[{index}] <- {rhs}`
     let assignIndex (lhs : SynExpr) (index : SynExpr) (rhs : SynExpr) : SynExpr =
         SynExpr.DotIndexedSet (lhs, index, rhs, range0, range0, range0)
+
+    /// { x = 3 ; y = 4 }, or { foo with x = 3 }, for example.
+    let createRecord (updateFrom : SynExpr option) (fields : (SynLongIdent * SynExpr) list) : SynExpr =
+        let updateFrom =
+            updateFrom
+            |> Option.map (fun updateFrom -> updateFrom, (range0, Some Fantomas.FCS.Text.Position.pos0))
+
+        let fields =
+            fields
+            |> List.map (fun (rfn, synExpr) -> SynExprRecordField ((rfn, true), Some range0, Some synExpr, None))
+
+        SynExpr.Record (None, updateFrom, fields, range0)

--- a/WoofWare.Whippet.Fantomas/WoofWare.Whippet.Fantomas.fsproj
+++ b/WoofWare.Whippet.Fantomas/WoofWare.Whippet.Fantomas.fsproj
@@ -54,7 +54,7 @@
       <PackagePath>/</PackagePath>
       <Link>README.md</Link>
     </None>
-    <None Include="version.json" />
+    <EmbeddedResource Include="version.json" />
     <EmbeddedResource Include="SurfaceBaseline.txt" />
   </ItemGroup>
 

--- a/WoofWare.Whippet.Fantomas/version.json
+++ b/WoofWare.Whippet.Fantomas/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3",
+  "version": "0.4",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
Having it in `AstHelper` was bizarre; it obviously belongs in `SynExpr`.